### PR TITLE
[TASK] update composer.json with schema for composer.typo3.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,12 @@
 {
-	"name": "georgringer/be_acl_file",
+	"name": "georgringer/be-acl-file",
 	"version": "0.0.4",
 	"description": "BE access via files",
-	"type": "typo3cms-extension"
+	"type": "typo3-cms-extension",
+	"replace": {
+		"be_acl_file": "*"
+	},
+	"require": {
+		"typo3/cms-core": "6.2.*"
+	}
 }


### PR DESCRIPTION
Schema is the same as for composer.typo3.org where _ are replaced with -, e.g. for typo3-ter/static-info-tables. Installation directory will be be_acl_file though.
